### PR TITLE
[ETCM-296] Add support for Mantis txs and tx receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ The configuration file is the one from section [1.5]. The arguments are tha plat
 
 **Using sbt**
 ```sh
-sbt "runLorre mantis testnet" -Dconfig.file='<platform> <network>'
+sbt -Dconfig.file='<path/to/config/file.conf>' "runLorre <platform> <network>"
 ```
 For example, using the configuration file in section [1.5] to run mantis/testnet indexer:
 ```sh
-sbt "runLorre mantis testnet" -Dconfig.file='/home/<username>/mantis-indexer-api/mantis.conf'
+sbt -Dconfig.file='/home/<username>/mantis-indexer-api/mantis.conf' "runLorre mantis testnet"
 ```
 **Using the `.jar` files**
 
@@ -170,11 +170,11 @@ The configuration file is the one from section [1.5]. No mantis node is needed.
 
 **Using sbt**
 ```sh
-sbt "runApi" -Dconfig.file='<platform> <network>'
+sbt -Dconfig.file='<path/to/config/file.conf>' runApi
 ```
 For example, using the configuration file in section [1.5] to run mantis/testnet indexer:
 ```sh
-sbt "runApi" -Dconfig.file='/home/<username>/mantis-indexer-api/mantis.conf'
+sbt -Dconfig.file='/home/<username>/mantis-indexer-api/mantis.conf' runApi
 ```
 **Using the `.jar` files**
 ```sh

--- a/conseil-api/src/main/resources/metadata/mantis.testnet.conf
+++ b/conseil-api/src/main/resources/metadata/mantis.testnet.conf
@@ -65,47 +65,41 @@
         hash {
           visible: true
         }
+        nonce {
+          visible: true
+        }
         block_hash {
           visible: true
         }
         block_number {
           visible: true
         }
+        transaction_index {
+          visible: true
+        }
         from {
-          visible: true
-        }
-        gas {
-          visible: true
-        }
-        gas_price {
-          visible: true
-        }
-        input {
-          visible: true
-        }
-        nonce {
           visible: true
         }
         to {
           visible: true
         }
-        transaction_index {
-          visible: true
-        }
         value {
           visible: true
         }
-        v {
+        gas_price {
           visible: true
-          display-name: "ECDSA Recovery ID"
         }
-        r {
+        gas {
           visible: true
-          display-name: "ECDSA Signature R"
         }
-        s {
+        input {
           visible: true
-          display-name: "ECDSA Signature S"
+        }
+        pending {
+          visible: true
+        }
+        is_outgoing {
+          visible: true
         }
       }
     }
@@ -150,13 +144,10 @@
         transaction_index {
           visible: true
         }
-        block_hash {
-          visible: true
-        }
         block_number {
           visible: true
         }
-        contract_address {
+        block_hash {
           visible: true
         }
         cumulative_gas_used {
@@ -165,13 +156,7 @@
         gas_used {
           visible: true
         }
-        logs_bloom {
-          visible: true
-        }
-        status {
-          visible: true
-        }
-        root {
+        contract_address {
           visible: true
         }
       }

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/mantis/MantisPersistence.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/mantis/MantisPersistence.scala
@@ -140,26 +140,24 @@ object MantisPersistence {
     * Convert form [[Transaction]] to [[Tables.TransactionsRow]]
     * TODO: This conversion should be done with the Chimney,
     *       but it's blocked due to the https://github.com/scala/bug/issues/11157
-    * FIXME: change to Mantis transaction (current implementation is for Ethereum)
     */
   implicit val transactionToTransactionsRow: Conversion[Id, Transaction, Tables.TransactionsRow] =
     new Conversion[Id, Transaction, Tables.TransactionsRow] {
       override def convert(from: Transaction) =
         Tables.TransactionsRow(
           hash = from.hash,
+          nonce = from.nonce,
           blockHash = from.blockHash,
           blockNumber = Integer.decode(from.blockNumber),
-          from = from.from,
-          gas = from.gas,
-          gasPrice = from.gasPrice,
-          input = from.input,
-          nonce = from.nonce,
-          to = from.to,
           transactionIndex = from.transactionIndex,
+          from = from.from,
+          to = from.to,
           value = hexStringToBigDecimal(from.value),
-          v = from.v,
-          r = from.r,
-          s = from.s
+          gasPrice = from.gasPrice,
+          gas = from.gas,
+          input = from.input,
+          pending = from.pending,
+          isOutgoing = from.isOutgoing
         )
     }
 
@@ -167,22 +165,18 @@ object MantisPersistence {
     * Convert form [[TransactionReceipt]] to [[Tables.ReceiptsRow]]
     * TODO: This conversion should be done with the Chimney,
     *       but it's blocked due to the https://github.com/scala/bug/issues/11157
-    * FIXME: change to Mantis transaction receipt (current implementation is for Ethereum)
     */
   implicit val transactionReceiptToReceiptsRow: Conversion[Id, TransactionReceipt, Tables.ReceiptsRow] =
     new Conversion[Id, TransactionReceipt, Tables.ReceiptsRow] {
       override def convert(from: TransactionReceipt) =
         Tables.ReceiptsRow(
-          blockHash = from.blockHash,
-          blockNumber = Integer.decode(from.blockNumber),
           transactionHash = from.transactionHash,
           transactionIndex = from.transactionIndex,
-          contractAddress = from.contractAddress,
+          blockNumber = Integer.decode(from.blockNumber),
+          blockHash = from.blockHash,
           cumulativeGasUsed = from.cumulativeGasUsed,
           gasUsed = from.gasUsed,
-          logsBloom = from.logsBloom,
-          status = from.status,
-          root = from.root
+          contractAddress = from.contractAddress
         )
     }
 

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/mantis/rpc/json/Transaction.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/mantis/rpc/json/Transaction.scala
@@ -5,18 +5,17 @@ package tech.cryptonomic.conseil.common.mantis.rpc.json
   * More info at: https://eth.wiki/json-rpc/API
   */
 case class Transaction(
+    hash: String,
+    nonce: String,
     blockHash: String,
     blockNumber: String,
-    from: String,
-    gas: String,
-    gasPrice: String,
-    hash: String,
-    input: String,
-    nonce: String,
-    to: Option[String],
     transactionIndex: String,
+    from: String,
+    to: Option[String],
     value: String,
-    v: String,
-    r: String,
-    s: String
+    gasPrice: String,
+    gas: String,
+    input: String,
+    pending: Option[Boolean],
+    isOutgoing: Option[Boolean]
 )

--- a/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/mantis/rpc/json/TransactionReceipt.scala
+++ b/conseil-common/src/main/scala/tech/cryptonomic/conseil/common/mantis/rpc/json/TransactionReceipt.scala
@@ -5,17 +5,12 @@ package tech.cryptonomic.conseil.common.mantis.rpc.json
   * More info at: https://eth.wiki/json-rpc/API
   */
 case class TransactionReceipt(
-    blockHash: String,
-    blockNumber: String,
-    contractAddress: Option[String],
-    cumulativeGasUsed: String,
-    from: String,
-    gasUsed: String,
-    logs: Seq[Log],
-    logsBloom: String,
-    status: Option[String],
-    root: Option[String],
-    to: Option[String],
     transactionHash: String,
-    transactionIndex: String
+    transactionIndex: String,
+    blockNumber: String,
+    blockHash: String,
+    cumulativeGasUsed: String,
+    gasUsed: String,
+    contractAddress: Option[String],
+    logs: Seq[Log]
 )

--- a/sql/mantis.sql
+++ b/sql/mantis.sql
@@ -43,19 +43,18 @@ CREATE TABLE mantis.blocks (
 -- Table is based on eth_getTransactionByHash from https://eth.wiki/json-rpc/API
 CREATE TABLE mantis.transactions (
   hash text NOT NULL PRIMARY KEY,
+  nonce text NOT NULL,
   block_hash text NOT NULL,
   block_number integer NOT NULL,
-  "from" text NOT NULL,
-  gas text NOT NULL,
-  gas_price text NOT NULL,
-  input text NOT NULL,
-  nonce text NOT NULL,
-  "to" text,
   transaction_index text NOT NULL,
+  "from" text NOT NULL,
+  "to" text,
   value numeric NOT NULL, -- value in wei
-  v text NOT NULL,
-  r text NOT NULL,
-  s text NOT NULL
+  gas_price text NOT NULL,
+  gas text NOT NULL,
+  input text NOT NULL,
+  pending boolean,
+  is_outgoing boolean
 );
 
 ALTER TABLE ONLY mantis.transactions
@@ -65,14 +64,11 @@ ALTER TABLE ONLY mantis.transactions
 CREATE TABLE mantis.receipts (
   transaction_hash text NOT NULL,
   transaction_index text NOT NULL,
-  block_hash text NOT NULL,
   block_number integer NOT NULL,
-  contract_address text,
+  block_hash text NOT NULL,
   cumulative_gas_used text NOT NULL,
   gas_used text NOT NULL,
-  logs_bloom text NOT NULL,
-  status text,
-  root text
+  contract_address text
 );
 
 -- Table is based on eth_getLogs from https://eth.wiki/json-rpc/API


### PR DESCRIPTION
This PR includes support for txs and txs receipts, which couldn't be indexed before.

Changes include Schema updates -> so the indexer and the API are not compatible with previous dbs and vice-versa. 

# How to test:
Following README's instructions, generate a **fresh db** with the updated `mantis.sql` and run the indexer and the API. To see the changes, mantis node should have al least one transfer transaction (smart contracts are not supported yet).
