### PR TITLE
[ETCM-318] Add script to drop and create db

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,23 +49,22 @@ $ cp /tmp/conseil-lorre.jar ~/path/to/your/directory/mantis-lorre.jar
 $ cp /tmp/conseil-api.jar ~/path/to/your/directory/mantis-api.jar
 ```
 
-**1.4 Generate db schema (necessary to run both Lorre and conseil-api)**
+**1.4 Create the database and generate mantis schema (necessary to run both Lorre and conseil-api)**
 
-Create DB and user and grant db privileges on that db to said user
-```sh
-$ sudo -u postgres psql
+Run the `db-creation.sh` script in the root of the project. This script will drop the db/user given in the configurations present in the file if they exist and create them again. Then it will run the `mantis.sql` file to generate the mantis schema.
 
-postgres=# create database conseil;
-postgres=# create user foo with encrypted password 'bar';
-postgres=# grant all privileges on database conseil to foo;
-```
-Connect to the db and generate the schema from `mantis.sql` in the repository
+Main configurations in the script:
+
 ```sh
-postgres=# \c conseil
-You are now connected to database "conseil" as user "postgres".
-conseil=# \i ~/mantis-indexer-api/sql/mantis.sql
+user="foo"
+pass="'bar'"
+db="conseil"
 ```
- After success output, the db is ready to be used by lorre and conseil
+
+These configurations are by default the same as in `mantis.conf`.
+Make sure to grant execution permission to the script before running it.
+
+After success output, the db is ready to be used by lorre and conseil.
 
 **1.5 Configuration Files**
 

--- a/db-creation.sh
+++ b/db-creation.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+################################################################
+##
+##   PostgresQL Database Creation Script
+##   Last Update: Nov 09, 2020
+##   Mantis
+##
+################################################################
+
+echo -e " # MANTIS-INDEXER-API - DB SCRIPT # \n"
+
+# Default schema
+script="$(pwd)/sql/mantis.sql"
+echo "- .sql file path: $script"
+
+# The db configs should be the same as the ones in the config
+# file used to run lorre/the API.
+user="foo"
+pass="'bar'"
+db="conseil"
+
+################################################################
+
+echo -e "- About to create $db database and $user user \n"
+
+sudo -u postgres psql << EOF
+    DROP DATABASE IF EXISTS $db;
+    DROP USER IF EXISTS $user;
+    CREATE DATABASE $db;
+    CREATE USER $user WITH ENCRYPTED PASSWORD $pass;
+    GRANT ALL PRIVILEGES ON DATABASE $db TO $user;
+    \c $db
+    \i /$script;
+    GRANT ALL PRIVILEGES ON SCHEMA mantis TO $user;
+    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mantis TO $user;
+EOF
+
+
+echo "Finished running db creation for mantis"
+
+### End of script ####


### PR DESCRIPTION
I'm adding the `db-creation.sh` script to avoid having to manually create and clean the db with its corresponding update in the `README`.

## How to test:

After giving it execution permission, run `db-creation.sh`. 
- Verify that there are no errors in the output
- Run the indexer and the API and verify that they properly connect to the db.
